### PR TITLE
Set up staging models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 target/
 dbt_packages/
 logs/
+venv

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -36,7 +36,7 @@ clean-targets:         # directories to be removed by `dbt clean`
 # using the `{{ config(...) }}` macro.
 
 models:
-  my_new_project:
+  jaffle_shop:
     # Applies to all files under models/example/
-    example:
-      +materialized: table
+    staging:
+      +materialized: view

--- a/macros/cents_to_dollar.sql
+++ b/macros/cents_to_dollar.sql
@@ -1,0 +1,21 @@
+{# A basic example for a project-wide macro to cast a column uniformly #}
+
+{% macro cents_to_dollars(column_name) -%}
+    {{ return(adapter.dispatch('cents_to_dollars')(column_name)) }}
+{%- endmacro %}
+
+{% macro default__cents_to_dollars(column_name) -%}
+    ({{ column_name }} / 100)::numeric(16, 2)
+{%- endmacro %}
+
+{% macro postgres__cents_to_dollars(column_name) -%}
+    ({{ column_name }}::numeric(16, 2) / 100)
+{%- endmacro %}
+
+{% macro bigquery__cents_to_dollars(column_name) %}
+    round(cast(({{ column_name }} / 100) as numeric), 2)
+{% endmacro %}
+
+{% macro fabric__cents_to_dollars(column_name) %}
+    cast({{ column_name }} / 100 as numeric(16,2))
+{% endmacro %}

--- a/models/staging/__sources.yml
+++ b/models/staging/__sources.yml
@@ -1,0 +1,24 @@
+version: 2
+
+sources:
+  - name: ecom
+    schema: raw_mock
+    description: E-commerce data for the Jaffle Shop
+    freshness:
+      warn_after:
+        count: 24
+        period: hour
+    tables:
+      - name: customers
+        description: One record per person who has purchased one or more items
+      - name: orders
+        description: One record per order (consisting of one or more order items)
+        loaded_at_field: ordered_at
+      - name: items
+        description: Items included in an order
+      - name: stores
+        loaded_at_field: opened_at
+      - name: products
+        description: One record per SKU for items sold in stores
+      - name: supplies
+        description: One record per supply per SKU of items sold in stores

--- a/models/staging/stg_customer.yml
+++ b/models/staging/stg_customer.yml
@@ -1,0 +1,11 @@
+models:
+  - name: stg_customers
+    description: Customer data with basic cleaning and transformation applied, one row per customer.
+    columns:
+      - name: customer_id
+        description: The unique key for each customer.
+        data_tests:
+          - not_null
+          - unique
+      - name: customer_name
+        description: The name of the customer.

--- a/models/staging/stg_customers.sql
+++ b/models/staging/stg_customers.sql
@@ -1,0 +1,23 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'customers') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        id as customer_id,
+
+        ---------- text
+        name as customer_name
+
+    from source
+
+)
+
+select * from renamed

--- a/models/staging/stg_locations.sql
+++ b/models/staging/stg_locations.sql
@@ -1,0 +1,29 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'stores') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        id as location_id,
+
+        ---------- text
+        name as location_name,
+
+        ---------- numerics
+        tax_rate,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day', 'opened_at') }} as opened_date
+
+    from source
+
+)
+
+select * from renamed

--- a/models/staging/stg_order_items.sql
+++ b/models/staging/stg_order_items.sql
@@ -1,0 +1,22 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'items') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        id as order_item_id,
+        order_id,
+        sku as product_id
+
+    from source
+
+)
+
+select * from renamed

--- a/models/staging/stg_order_items.yml
+++ b/models/staging/stg_order_items.yml
@@ -1,0 +1,16 @@
+models:
+  - name: stg_order_items
+    description: Individual food and drink items that make up our orders, one row per item.
+    columns:
+      - name: order_item_id
+        description: The unique key for each order item.
+        data_tests:
+          - not_null
+          - unique
+      - name: order_id
+        description: The corresponding order each order item belongs to
+        data_tests:
+          - not_null
+          - relationships:
+              to: ref('stg_orders')
+              field: order_id

--- a/models/staging/stg_orders.sql
+++ b/models/staging/stg_orders.sql
@@ -1,0 +1,33 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'orders') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        id as order_id,
+        store_id as location_id,
+        customer as customer_id,
+
+        ---------- numerics
+        subtotal as subtotal_cents,
+        tax_paid as tax_paid_cents,
+        order_total as order_total_cents,
+        {{ cents_to_dollars('subtotal') }} as subtotal,
+        {{ cents_to_dollars('tax_paid') }} as tax_paid,
+        {{ cents_to_dollars('order_total') }} as order_total,
+
+        ---------- timestamps
+        {{ dbt.date_trunc('day','ordered_at') }} as ordered_at
+
+    from source
+
+)
+
+select * from renamed

--- a/models/staging/stg_orders.yml
+++ b/models/staging/stg_orders.yml
@@ -1,0 +1,12 @@
+models:
+  - name: stg_orders
+    description: Order data with basic cleaning and transformation applied, one row per order.
+    data_tests:
+      - dbt_utils.expression_is_true:
+          expression: "order_total - tax_paid = subtotal"
+    columns:
+      - name: order_id
+        description: The unique key for each order.
+        data_tests:
+          - not_null
+          - unique

--- a/models/staging/stg_products.sql
+++ b/models/staging/stg_products.sql
@@ -1,0 +1,34 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'products') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        sku as product_id,
+
+        ---------- text
+        name as product_name,
+        type as product_type,
+        description as product_description,
+
+
+        ---------- numerics
+        {{ cents_to_dollars('price') }} as product_price,
+
+        ---------- booleans
+        coalesce(type = 'jaffle', false) as is_food_item,
+
+        coalesce(type = 'beverage', false) as is_drink_item
+
+    from source
+
+)
+
+select * from renamed

--- a/models/staging/stg_products.yml
+++ b/models/staging/stg_products.yml
@@ -1,0 +1,9 @@
+models:
+  - name: stg_products
+    description: Product (food and drink items that can be ordered) data with basic cleaning and transformation applied, one row per product.
+    columns:
+      - name: product_id
+        description: The unique key for each product.
+        data_tests:
+          - not_null
+          - unique

--- a/models/staging/stg_supplies.sql
+++ b/models/staging/stg_supplies.sql
@@ -1,0 +1,31 @@
+with
+
+source as (
+
+    select * from {{ source('ecom', 'supplies') }}
+
+),
+
+renamed as (
+
+    select
+
+        ----------  ids
+        {{ dbt_utils.generate_surrogate_key(['id', 'sku']) }} as supply_uuid,
+        id as supply_id,
+        sku as product_id,
+
+        ---------- text
+        name as supply_name,
+
+        ---------- numerics
+        {{ cents_to_dollars('cost') }} as supply_cost,
+
+        ---------- booleans
+        perishable as is_perishable_supply
+
+    from source
+
+)
+
+select * from renamed

--- a/models/staging/stg_supplies.yml
+++ b/models/staging/stg_supplies.yml
@@ -1,0 +1,12 @@
+models:
+  - name: stg_supplies
+    description: >
+      List of our supply expenses data with basic cleaning and transformation applied.
+
+      One row per supply cost, not per supply. As supply costs fluctuate they receive a new row with a new UUID. Thus there can be multiple rows per supply_id.
+    columns:
+      - name: supply_uuid
+        description: The unique key of our supplies per cost.
+        data_tests:
+          - not_null
+          - unique

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,0 +1,4 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.3.0
+sha1_hash: 226ae69cdfbc9367e2aa2c472b01f99dbce11de0

--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.3.0


### PR DESCRIPTION
# dbt-jaffle-shop Staging Models Implementation

## What
This PR implements the foundational staging layer for our e-commerce data warehouse following dbt best practices.

## Why
- Establish clean, tested data models for downstream consumption
- Standardize naming conventions and data transformations
- Enable data quality testing at the source level

## Key Changes
1. Added staging models for core entities:
   - Products
   - Orders
   - Customers
   - Locations
   - Supplies
   - Order Items

2. Implemented cross-platform `cents_to_dollars` macro for consistent monetary calculations

3. Added source freshness checks

4. Established data testing:
   - Primary key validations
   - Referential integrity checks
   - Custom business logic tests (e.g., order total validation)

## Testing
```
dbt run --models staging
dbt test --models staging
```

## Documentation
Each model includes descriptions and column-level documentation following dbt standards.